### PR TITLE
feat: summary detail, session preview, pbcopy prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,24 @@ node dist/bin.js --help
 ```sh
 ccrelay doctor
 ccrelay inspect [--source claude|codex] [--pick]
-ccrelay write [--from claude|codex] [--locale en|ja] [--session <id>] [--latest] [--target claude|codex]
-ccrelay to codex [--dry-run] [--from claude] [--locale en|ja] [--session <id>] [--latest] [--no-write]
-ccrelay to claude [--dry-run] [--from codex] [--locale en|ja] [--session <id>] [--latest] [--no-write]
+ccrelay write [--from claude|codex] [--locale en|ja] [--session <id>] [--latest] [--detail summary|standard|full]
+ccrelay to codex [--dry-run] [--from claude] [--locale en|ja] [--session <id>] [--latest] [--detail summary|standard|full] [--no-write]
+ccrelay to claude [--dry-run] [--from codex] [--locale en|ja] [--session <id>] [--latest] [--detail summary|standard|full] [--no-write]
 ```
 
 `write` creates `.handoff/current.md` and does not launch another agent.
 
-By default, commands ask for missing options interactively. For example, `write` asks for source agent, locale, target agent, whether to include the full diff, and then opens the session picker. `to codex` and `to claude` ask for the source agent and locale before choosing a session. `inspect` asks whether to show all sessions or filter by source.
+By default, commands ask for missing options interactively. For example, `write` asks for source agent, locale, handoff detail level, and then opens the session picker. `to codex` and `to claude` ask for the source agent and locale before choosing a session. `inspect` asks whether to show all sessions or filter by source.
 
-The session picker supports fuzzy search. Type to filter, use the arrow keys to move, and press Enter to select. Use `--latest` to skip the picker and choose the newest matching session automatically, or `--session <id>` to choose a specific session.
+The detail level controls how much context lands in `.handoff/current.md`:
+
+- `summary` — invokes the source agent CLI to compress the session log into a short brief; the long `Session Summary` is omitted. Set `AGENT_HANDOFF_SUMMARIZER_BIN` to override the summarizer command (defaults to `claude --print` or `codex exec -`).
+- `standard` — embeds the full `continues inspect` summary as before.
+- `full` — `standard` plus the full `git diff`.
+
+The session picker supports fuzzy search. Type to filter, use the arrow keys to move, press Tab to toggle a panel showing the latest message of the highlighted session, and press Enter to select. Use `--latest` to skip the picker and choose the newest matching session automatically, or `--session <id>` to choose a specific session.
+
+On macOS, `write` asks whether to copy the generated handoff to `pbcopy` after writing it.
 
 `to codex` and `to claude` update the handoff by default, write the target-specific prompt to `.handoff/last-codex-prompt.md` or `.handoff/last-claude-prompt.md`, and then launch the target agent unless `--dry-run` is set.
 
@@ -61,6 +69,7 @@ ccrelay to claude --from codex --locale ja --dry-run
 AGENT_HANDOFF_CONTINUES_BIN="npx continues"
 AGENT_HANDOFF_CODEX_BIN="codex"
 AGENT_HANDOFF_CLAUDE_BIN="claude"
+AGENT_HANDOFF_SUMMARIZER_BIN="claude --print"
 ```
 
 ## Safety

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "agent-handoff",
+  "name": "ccrelay",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agent-handoff",
+      "name": "ccrelay",
       "version": "0.1.0",
       "license": "MIT",
       "bin": {
-        "agent-handoff": "dist/bin.js"
+        "ccrelay": "dist/bin.js"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,12 +44,13 @@ function printHelp(): void {
 Usage:
   ccrelay doctor
   ccrelay inspect [--source claude|codex] [--pick]
-  ccrelay write [--from claude|codex] [--locale en|ja] [--session id] [--latest] [--target claude|codex] [--include-diff]
-  ccrelay to codex [--dry-run] [--from claude|codex] [--locale en|ja] [--session id] [--latest] [--no-write]
-  ccrelay to claude [--dry-run] [--from claude|codex] [--locale en|ja] [--session id] [--latest] [--no-write]
+  ccrelay write [--from claude|codex] [--locale en|ja] [--session id] [--latest] [--detail summary|standard|full] [--include-diff]
+  ccrelay to codex [--dry-run] [--from claude|codex] [--locale en|ja] [--session id] [--latest] [--detail summary|standard|full] [--no-write]
+  ccrelay to claude [--dry-run] [--from claude|codex] [--locale en|ja] [--session id] [--latest] [--detail summary|standard|full] [--no-write]
 
 Environment:
   AGENT_HANDOFF_CONTINUES_BIN="npx continues"
   AGENT_HANDOFF_CODEX_BIN="codex"
-  AGENT_HANDOFF_CLAUDE_BIN="claude"`);
+  AGENT_HANDOFF_CLAUDE_BIN="claude"
+  AGENT_HANDOFF_SUMMARIZER_BIN="claude --print"  # used for --detail summary; defaults to source agent CLI`);
 }

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -31,7 +31,7 @@ export async function runInspect(argv: string[]): Promise<void> {
   }
 
   if (options.pick) {
-    const selected = await pickSession(sessions);
+    const selected = await pickSession(sessions, { cwd: root });
     console.log(getSessionId(selected));
     return;
   }

--- a/src/commands/to.ts
+++ b/src/commands/to.ts
@@ -14,6 +14,7 @@ export async function runTo(target: TargetAgent, argv: string[]): Promise<void> 
     from: "value",
     locale: "value",
     session: "value",
+    detail: "value",
   });
 
   const root = await repoRoot(process.cwd());
@@ -27,11 +28,12 @@ export async function runTo(target: TargetAgent, argv: string[]): Promise<void> 
       const resolvedLocale = await resolveLocale(options.locale);
       const from = typeof options.from === "string" ? options.from : await pickFromAgent(target);
 
-      const writeArgs: string[] = ["--from", from, "--locale", resolvedLocale, "--target", target];
+      const writeArgs: string[] = ["--from", from, "--locale", resolvedLocale];
       if (typeof options.session === "string") writeArgs.push("--session", options.session);
       if (options.latest) writeArgs.push("--latest");
+      if (typeof options.detail === "string") writeArgs.push("--detail", options.detail);
 
-      await runWrite(writeArgs, { root, silent: true });
+      await runWrite(writeArgs, { root, silent: true, skipPbcopyPrompt: true });
       return resolvedLocale;
     });
   } else {

--- a/src/commands/write.ts
+++ b/src/commands/write.ts
@@ -2,17 +2,20 @@ import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { parseOptions } from "../lib/args.js";
 import { pickChoice } from "../lib/choicePicker.js";
-import { chooseSession, getSessionId, getSessionSource, inspectSessionMarkdown, listSessions } from "../lib/continues.js";
+import { chooseSession, getSessionId, inspectSessionMarkdown, listSessions } from "../lib/continues.js";
 import { gitDiff, gitDiffStat, gitStatus, repoRoot } from "../lib/git.js";
 import { buildHandoffMarkdown, fileExists, writeHandoffFile } from "../lib/handoff.js";
-import { resolveLocale } from "../lib/interactiveOptions.js";
+import { maybeOfferPbcopy } from "../lib/pbcopy.js";
+import { resolveDetail, resolveLocale } from "../lib/interactiveOptions.js";
 import { withAlternateScreen } from "../lib/screen.js";
 import { pickSession } from "../lib/sessionPicker.js";
-import type { Agent, Locale, SessionCandidate, TargetAgent } from "../lib/types.js";
+import { summarizeSession } from "../lib/summarize.js";
+import type { Agent, Detail, Locale, SessionCandidate } from "../lib/types.js";
 
 interface WriteInjected {
   root?: string;
   silent?: boolean;
+  skipPbcopyPrompt?: boolean;
 }
 
 interface WriteResult {
@@ -27,38 +30,35 @@ export async function runWrite(argv: string[], injected: WriteInjected = {}): Pr
     from: "value",
     locale: "value",
     session: "value",
-    target: "value",
+    detail: "value",
   });
 
   validateAgent(options.from, "--from");
-  validateAgent(options.target, "--target");
 
   const root = injected.root ?? await repoRoot(process.cwd());
 
-  const { locale, source, target, session } = await withAlternateScreen(async (): Promise<{
+  const { locale, source, session, detail } = await withAlternateScreen(async (): Promise<{
     locale: Locale;
     source: Agent;
-    target: TargetAgent | "unspecified";
     session: SessionCandidate;
+    detail: Detail;
   }> => {
     const locale = await resolveLocale(options.locale);
     const source: Agent = typeof options.from === "string" ? options.from as Agent : await pickAgent("Create handoff from which source agent?");
-    const target: TargetAgent | "unspecified" = typeof options.target === "string" ? options.target as TargetAgent : await pickTarget();
+    const detail = await resolveDetail(options.detail ?? (options.includeDiff ? "full" : undefined));
 
     const sessionIdOption = typeof options.session === "string" ? options.session : undefined;
     const sessions = await listSessions({ cwd: root, source });
     const session = sessionIdOption || options.latest
       ? chooseSession(sessions, { cwd: root, source, sessionId: sessionIdOption })
-      : await pickSession(sessions);
+      : await pickSession(sessions, { cwd: root });
 
     if (!session) {
       throw new Error(source ? `No ${source} session found by continues for this repository.` : "No session found by continues for this repository.");
     }
 
-    return { locale, source, target, session };
+    return { locale, source, session, detail };
   });
-
-  const includeDiff = Boolean(options.includeDiff);
 
   const sessionId = getSessionId(session);
   if (!sessionId) {
@@ -68,28 +68,45 @@ export async function runWrite(argv: string[], injected: WriteInjected = {}): Pr
   const sessionSummary = await inspectSessionMarkdown(sessionId, { cwd: root });
   const status = await gitStatus(root);
   const diffStat = await gitDiffStat(root);
-  const diff = includeDiff ? await gitDiff(root) : "";
+  const diff = detail === "full" ? await gitDiff(root) : "";
   const repoInstructions = await detectRepoInstructions(root);
+
+  let compactSummary: string | undefined;
+  if (detail === "summary") {
+    if (!injected.silent) console.log("Summarizing session via source agent...");
+    try {
+      compactSummary = await summarizeSession(sessionSummary, { source, locale, cwd: root });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!injected.silent) console.warn(`Summarization failed, falling back to standard detail: ${message}`);
+    }
+  }
 
   const content = buildHandoffMarkdown({
     generatedAt: new Date().toISOString(),
     repository: root,
     sourceAgent: source,
-    targetAgent: target,
     sessionId,
-    sessionSummary,
+    sessionSummary: detail === "summary" && compactSummary ? undefined : sessionSummary,
+    compactSummary,
     modifiedFiles: status.split("\n").filter(Boolean),
     gitStatus: status,
     gitDiffStat: diffStat,
     diff,
     repoInstructions,
     locale,
+    detail,
   });
 
   const path = await writeHandoffFile(root, content);
   if (!injected.silent) {
     console.log(`Wrote ${path}`);
   }
+
+  if (!injected.skipPbcopyPrompt) {
+    await maybeOfferPbcopy({ label: "handoff", payload: content, locale });
+  }
+
   return { path, root, sessionId, sourceAgent: source };
 }
 
@@ -97,14 +114,6 @@ async function pickAgent(title: string): Promise<Agent> {
   return pickChoice(title, [
     { label: "codex", value: "codex", description: "continue from a Codex session" },
     { label: "claude", value: "claude", description: "continue from a Claude Code session" },
-  ]);
-}
-
-async function pickTarget(): Promise<TargetAgent | "unspecified"> {
-  return pickChoice("Who is the target agent?", [
-    { label: "unspecified", value: "unspecified", description: "write handoff only" },
-    { label: "claude", value: "claude", description: "handoff is for Claude Code" },
-    { label: "codex", value: "codex", description: "handoff is for Codex" },
   ]);
 }
 
@@ -120,7 +129,7 @@ async function detectRepoInstructions(root: string): Promise<string[]> {
   return entries;
 }
 
-function validateAgent(value: unknown, flag: string): asserts value is Agent | TargetAgent | undefined {
+function validateAgent(value: unknown, flag: string): asserts value is Agent | undefined {
   if (value && (typeof value !== "string" || !["claude", "codex"].includes(value))) {
     throw new Error(`${flag} must be claude or codex.`);
   }

--- a/src/lib/exec.ts
+++ b/src/lib/exec.ts
@@ -3,20 +3,21 @@ import type { RunOptions, RunResult } from "./types.js";
 
 export async function run(command: string, args: string[] = [], options: RunOptions = {}): Promise<RunResult> {
   return new Promise((resolve) => {
+    const hasStdin = typeof options.stdin === "string";
     const child = spawn(command, args, {
       cwd: options.cwd,
       env: options.env ?? process.env,
       shell: options.shell ?? false,
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: [hasStdin ? "pipe" : "ignore", "pipe", "pipe"],
     });
 
     let stdout = "";
     let stderr = "";
 
-    child.stdout.on("data", (chunk: Buffer) => {
+    child.stdout?.on("data", (chunk: Buffer) => {
       stdout += chunk.toString();
     });
-    child.stderr.on("data", (chunk: Buffer) => {
+    child.stderr?.on("data", (chunk: Buffer) => {
       stderr += chunk.toString();
     });
     child.on("error", (error) => {
@@ -25,6 +26,10 @@ export async function run(command: string, args: string[] = [], options: RunOpti
     child.on("close", (code) => {
       resolve({ ok: code === 0, code, stdout, stderr });
     });
+
+    if (hasStdin && child.stdin) {
+      child.stdin.end(options.stdin);
+    }
   });
 }
 

--- a/src/lib/handoff.ts
+++ b/src/lib/handoff.ts
@@ -40,6 +40,12 @@ function buildEnglishHandoffMarkdown(data: HandoffData): string {
   const modifiedFiles = data.modifiedFiles.length > 0
     ? data.modifiedFiles.map((line) => `- \`${line}\``).join("\n")
     : "- (no modified files reported by git status)";
+  const compactBlock = data.compactSummary
+    ? `\n## Compact Summary\n\n${data.compactSummary}\n`
+    : "";
+  const sessionBlock = data.sessionSummary
+    ? `\n## Session Summary\n\n${data.sessionSummary}\n`
+    : "";
 
   return `# Agent Handoff
 
@@ -47,8 +53,8 @@ function buildEnglishHandoffMarkdown(data: HandoffData): string {
 - Generated at: ${data.generatedAt}
 - Repository: ${data.repository}
 - Source agent: ${data.sourceAgent ?? "unknown"}
-- Target agent: ${data.targetAgent ?? "unspecified"}
 - Session id: ${data.sessionId ?? "unknown"}
+- Detail: ${data.detail}
 
 ## Critical Instructions
 - Continue from the current working tree.
@@ -61,11 +67,7 @@ Continue the current repository work safely from the latest available agent sess
 
 ## Current State
 This handoff was generated from the current workspace plus the selected session summary. Verify the workspace before making edits.
-
-## Session Summary
-
-${data.sessionSummary || "(continues did not provide a session summary)"}
-
+${compactBlock}${sessionBlock}
 ## Modified Files
 ${modifiedFiles}
 
@@ -101,6 +103,12 @@ function buildJapaneseHandoffMarkdown(data: HandoffData): string {
   const modifiedFiles = data.modifiedFiles.length > 0
     ? data.modifiedFiles.map((line) => `- \`${line}\``).join("\n")
     : "- (git status で変更中のファイルは検出されませんでした)";
+  const compactBlock = data.compactSummary
+    ? `\n## 要約\n\n${data.compactSummary}\n`
+    : "";
+  const sessionBlock = data.sessionSummary
+    ? `\n## Session Summary\n\n以下は \`continues\` から得た session summary です。原文の情報を保つため、内容は翻訳せずそのまま残しています。\n\n${data.sessionSummary}\n`
+    : "";
 
   return `# Agent Handoff
 
@@ -108,9 +116,9 @@ function buildJapaneseHandoffMarkdown(data: HandoffData): string {
 - 生成日時: ${data.generatedAt}
 - リポジトリ: ${data.repository}
 - 引き継ぎ元 agent: ${data.sourceAgent ?? "unknown"}
-- 引き継ぎ先 agent: ${data.targetAgent ?? "unspecified"}
 - Session id: ${data.sessionId ?? "unknown"}
 - Locale: ja
+- Detail: ${data.detail}
 
 ## 重要な指示
 - 現在の working tree から作業を継続すること。
@@ -124,13 +132,7 @@ function buildJapaneseHandoffMarkdown(data: HandoffData): string {
 
 ## 現在の状態
 この handoff は、現在の workspace と選択された session summary から生成されています。作業前に必ず実際の workspace を確認してください。
-
-## Session Summary
-
-以下は \`continues\` から得た session summary です。原文の情報を保つため、内容は翻訳せずそのまま残しています。
-
-${data.sessionSummary || "(\`continues\` から session summary は取得できませんでした)"}
-
+${compactBlock}${sessionBlock}
 ## 変更中のファイル
 ${modifiedFiles}
 

--- a/src/lib/interactiveOptions.ts
+++ b/src/lib/interactiveOptions.ts
@@ -1,5 +1,5 @@
 import { pickChoice } from "./choicePicker.js";
-import type { Locale } from "./types.js";
+import type { Detail, Locale } from "./types.js";
 
 export function parseLocale(value: unknown): Locale {
   if (value === "en" || value === "ja") return value;
@@ -11,5 +11,19 @@ export async function resolveLocale(value: unknown): Promise<Locale> {
   return pickChoice("Generate handoff in which locale?", [
     { label: "ja", value: "ja", description: "Japanese handoff sections and prompts" },
     { label: "en", value: "en", description: "English handoff sections and prompts" },
+  ]);
+}
+
+export function parseDetail(value: unknown): Detail {
+  if (value === "summary" || value === "standard" || value === "full") return value;
+  throw new Error("--detail must be summary, standard, or full.");
+}
+
+export async function resolveDetail(value: unknown): Promise<Detail> {
+  if (value !== undefined) return parseDetail(value);
+  return pickChoice("How much detail should the handoff include?", [
+    { label: "summary", value: "summary", description: "LLM-compressed summary only (smallest context)" },
+    { label: "standard", value: "standard", description: "full session summary from continues" },
+    { label: "full", value: "full", description: "standard plus full git diff" },
   ]);
 }

--- a/src/lib/pbcopy.ts
+++ b/src/lib/pbcopy.ts
@@ -1,0 +1,33 @@
+import { platform } from "node:os";
+import { pickChoice } from "./choicePicker.js";
+import { run } from "./exec.js";
+import { withAlternateScreen } from "./screen.js";
+import type { Locale } from "./types.js";
+
+interface PbcopyOfferOptions {
+  label: string;
+  payload: string;
+  locale?: Locale;
+}
+
+export async function maybeOfferPbcopy({ label, payload }: PbcopyOfferOptions): Promise<boolean> {
+  if (platform() !== "darwin") return false;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
+  if (!payload) return false;
+
+  const choice = await withAlternateScreen(() => pickChoice<"yes" | "no">(`Copy ${label} to pbcopy?`, [
+    { label: "yes", value: "yes", description: "send to clipboard" },
+    { label: "no", value: "no", description: "skip" },
+  ]));
+
+  if (choice !== "yes") return false;
+
+  const result = await run("pbcopy", [], { stdin: payload });
+  if (!result.ok) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+    console.warn(`pbcopy failed: ${detail}`);
+    return false;
+  }
+  console.log(`Copied ${label} to pbcopy.`);
+  return true;
+}

--- a/src/lib/sessionPicker.ts
+++ b/src/lib/sessionPicker.ts
@@ -3,6 +3,7 @@ import { enterAlternateScreen, exitAlternateScreen } from "./screen.js";
 import {
   getSessionId,
   getSessionSource,
+  inspectSessionMarkdown,
   sessionPath,
   sessionTime,
   sessionTitle,
@@ -13,7 +14,16 @@ interface PickerState {
   query: string;
   cursor: number;
   offset: number;
+  showDetail: boolean;
 }
+
+interface DetailEntry {
+  status: "loading" | "ready" | "error";
+  preview?: string;
+  error?: string;
+}
+
+const detailCache = new Map<string, DetailEntry>();
 
 const styles = {
   reset: "\x1b[0m",
@@ -24,12 +34,12 @@ const styles = {
   selected: "\x1b[48;5;60m\x1b[97m",
 };
 
-export async function pickSession(sessions: SessionCandidate[]): Promise<SessionCandidate> {
+export async function pickSession(sessions: SessionCandidate[], options: { cwd?: string } = {}): Promise<SessionCandidate> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     throw new Error("Interactive session picker requires a TTY. Re-run with --latest or --session <id>.");
   }
 
-  const state: PickerState = { query: "", cursor: 0, offset: 0 };
+  const state: PickerState = { query: "", cursor: 0, offset: 0, showDetail: false };
   const previousRawMode = process.stdin.isRaw;
   readline.emitKeypressEvents(process.stdin);
   process.stdin.setRawMode(true);
@@ -53,6 +63,28 @@ export async function pickSession(sessions: SessionCandidate[]): Promise<Session
       reject(error);
     };
 
+    const requestDetail = (session: SessionCandidate | undefined): void => {
+      if (!session || !state.showDetail) return;
+      const id = getSessionId(session);
+      if (!id || detailCache.has(id)) return;
+      detailCache.set(id, { status: "loading" });
+      inspectSessionMarkdown(id, { cwd: options.cwd })
+        .then((md) => {
+          detailCache.set(id, { status: "ready", preview: extractLatestMessage(md) });
+          render(sessions, state);
+        })
+        .catch((error: unknown) => {
+          detailCache.set(id, { status: "error", error: error instanceof Error ? error.message : String(error) });
+          render(sessions, state);
+        });
+    };
+
+    const rerender = (): void => {
+      const matches = filteredSessions(sessions, state.query);
+      requestDetail(matches[state.cursor]);
+      render(sessions, state);
+    };
+
     const onKeypress = (input: string, key: readline.Key): void => {
       const matches = filteredSessions(sessions, state.query);
       if (key.ctrl && key.name === "c") {
@@ -68,28 +100,33 @@ export async function pickSession(sessions: SessionCandidate[]): Promise<Session
         fail(new Error("Session selection cancelled."));
         return;
       }
+      if (key.name === "tab") {
+        state.showDetail = !state.showDetail;
+        rerender();
+        return;
+      }
       if (key.name === "backspace") {
         state.query = state.query.slice(0, -1);
         state.cursor = 0;
         state.offset = 0;
-        render(sessions, state);
+        rerender();
         return;
       }
       if (key.name === "up") {
         state.cursor = Math.max(0, state.cursor - 1);
-        render(sessions, state);
+        rerender();
         return;
       }
       if (key.name === "down") {
         state.cursor = Math.min(Math.max(0, matches.length - 1), state.cursor + 1);
-        render(sessions, state);
+        rerender();
         return;
       }
       if (input && input >= " " && input !== "\x7f") {
         state.query += input;
         state.cursor = 0;
         state.offset = 0;
-        render(sessions, state);
+        rerender();
       }
     };
 
@@ -102,14 +139,14 @@ export async function pickSession(sessions: SessionCandidate[]): Promise<Session
 function render(sessions: SessionCandidate[], state: PickerState): void {
   const matches = filteredSessions(sessions, state.query);
   if (state.cursor >= matches.length) state.cursor = Math.max(0, matches.length - 1);
-  const visibleCount = visibleSessionCount();
+  const visibleCount = visibleSessionCount(state.showDetail);
   state.offset = scrollOffset(state.offset, state.cursor, visibleCount, matches.length);
 
   renderClear();
   const shown = Math.min(matches.length, visibleCount);
   const windowed = matches.slice(state.offset, state.offset + shown);
   process.stdout.write(`${styles.bold}Select session${styles.reset}  ${styles.dim}${matches.length}/${sessions.length} matches${styles.reset}\n`);
-  process.stdout.write(`${styles.dim}Type to fuzzy search. Up/Down move. Enter choose. Esc cancel.${styles.reset}\n\n`);
+  process.stdout.write(`${styles.dim}Type to fuzzy search. Up/Down move. Enter choose. Tab toggle detail. Esc cancel.${styles.reset}\n\n`);
   process.stdout.write(`${styles.cyan}?${styles.reset} ${state.query || styles.dim + "search sessions" + styles.reset}\n\n`);
 
   if (matches.length === 0) {
@@ -131,6 +168,64 @@ function render(sessions: SessionCandidate[], state: PickerState): void {
   if (remaining > 0) {
     process.stdout.write(`${styles.dim}↓ ${remaining} more results. Keep pressing Down or refine the query.${styles.reset}\n`);
   }
+
+  if (state.showDetail) {
+    const selected = matches[state.cursor];
+    process.stdout.write("\n");
+    process.stdout.write(`${styles.bold}── Latest message ──${styles.reset}\n`);
+    process.stdout.write(formatDetailPanel(selected));
+    process.stdout.write("\n");
+  }
+}
+
+function formatDetailPanel(session: SessionCandidate | undefined): string {
+  if (!session) return `${styles.dim}(no session selected)${styles.reset}\n`;
+  const id = getSessionId(session);
+  if (!id) return `${styles.dim}(session has no id)${styles.reset}\n`;
+  const entry = detailCache.get(id);
+  if (!entry || entry.status === "loading") {
+    return `${styles.dim}Loading latest message...${styles.reset}\n`;
+  }
+  if (entry.status === "error") {
+    return `${styles.yellow}Failed to load: ${entry.error ?? "unknown error"}${styles.reset}\n`;
+  }
+  if (!entry.preview) {
+    return `${styles.dim}(no recent message available)${styles.reset}\n`;
+  }
+  const lines = entry.preview.split("\n").slice(0, detailPanelLineLimit());
+  return lines.map((line) => `  ${truncateForWidth(line, terminalWidth() - 2)}`).join("\n") + "\n";
+}
+
+function truncateForWidth(value: string, width: number): string {
+  if (value.length <= width) return value;
+  return `${value.slice(0, Math.max(0, width - 1))}…`;
+}
+
+function detailPanelLineLimit(): number {
+  return 8;
+}
+
+export function extractLatestMessage(markdown: string): string {
+  if (!markdown) return "";
+  const lines = markdown.split("\n");
+  const messageHeader = /^###\s+(User|Assistant)\b/;
+  let lastMessageIndex = -1;
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    if (messageHeader.test(lines[i])) {
+      lastMessageIndex = i;
+      break;
+    }
+  }
+  if (lastMessageIndex === -1) return lines.slice(-12).join("\n").trim();
+
+  let endIndex = lines.length;
+  for (let i = lastMessageIndex + 1; i < lines.length; i += 1) {
+    if (/^#{2,6}\s/.test(lines[i])) {
+      endIndex = i;
+      break;
+    }
+  }
+  return lines.slice(lastMessageIndex, endIndex).join("\n").trim();
 }
 
 function renderClear(): void {
@@ -231,9 +326,9 @@ function terminalWidth(): number {
   return Math.max(40, process.stdout.columns || 80);
 }
 
-function visibleSessionCount(): number {
+function visibleSessionCount(showDetail = false): number {
   const rows = process.stdout.rows || 24;
-  const reservedRows = 8;
+  const reservedRows = 8 + (showDetail ? detailPanelLineLimit() + 2 : 0);
   const rowHeight = 4;
   return Math.max(1, Math.min(12, Math.floor((rows - reservedRows) / rowHeight)));
 }

--- a/src/lib/summarize.ts
+++ b/src/lib/summarize.ts
@@ -1,0 +1,74 @@
+import { run } from "./exec.js";
+import { targetCommand } from "./prompt.js";
+import type { Agent, CommandSpec, Locale } from "./types.js";
+
+interface SummarizeOptions {
+  source: Agent;
+  locale: Locale;
+  cwd?: string;
+}
+
+export async function summarizeSession(sessionMarkdown: string, { source, locale, cwd }: SummarizeOptions): Promise<string> {
+  if (!sessionMarkdown.trim()) return "";
+
+  const command = summarizerCommand(source);
+  const prompt = buildSummarizerPrompt(sessionMarkdown, locale);
+  const result = await run(command.bin, command.args, { cwd, stdin: prompt });
+  if (!result.ok) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`;
+    throw new Error(`Summarizer failed (${command.bin} ${command.args.join(" ")}): ${detail}`);
+  }
+  return result.stdout.trim();
+}
+
+function summarizerCommand(source: Agent): CommandSpec {
+  const configured = process.env.AGENT_HANDOFF_SUMMARIZER_BIN;
+  if (configured) return splitCommand(configured);
+
+  const base = splitCommand(targetCommand(source));
+  if (source === "claude") return { bin: base.bin, args: [...base.args, "--print"] };
+  if (source === "codex") return { bin: base.bin, args: [...base.args, "exec", "-"] };
+  return base;
+}
+
+function buildSummarizerPrompt(sessionMarkdown: string, locale: Locale): string {
+  if (locale === "ja") {
+    return [
+      "以下はコーディング agent のセッション ログです。次の agent が作業を継続できるよう、最大 25 行で要約してください。",
+      "",
+      "出力には以下を含めてください:",
+      "- 目的 / 達成しようとしていること",
+      "- 現在の状態 / 完了済みの作業",
+      "- 未解決の事項 / 次のアクション",
+      "- 重要な決定事項や制約",
+      "",
+      "コマンド、ファイルパス、識別子、エラーメッセージは原文のまま保持してください。",
+      "前置きや補足は書かず、要約本文のみ返してください。",
+      "",
+      "--- session log ---",
+      sessionMarkdown,
+    ].join("\n");
+  }
+
+  return [
+    "The following is a coding agent session log. Summarize it in at most 25 lines so the next agent can continue.",
+    "",
+    "Include:",
+    "- Goal / what is being attempted",
+    "- Current state / what is done",
+    "- Open items / next actions",
+    "- Key decisions or constraints",
+    "",
+    "Preserve commands, file paths, identifiers, and error messages verbatim.",
+    "Output only the summary, no preamble.",
+    "",
+    "--- session log ---",
+    sessionMarkdown,
+  ].join("\n");
+}
+
+function splitCommand(value: string): CommandSpec {
+  const parts = value.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g)?.map((part) => part.replace(/^["']|["']$/g, "")) ?? [];
+  if (parts.length === 0) throw new Error("Empty command.");
+  return { bin: parts[0], args: parts.slice(1) };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 export type Agent = "claude" | "codex";
 export type TargetAgent = Agent;
 export type Locale = "en" | "ja";
+export type Detail = "summary" | "standard" | "full";
 
 export interface CommandSpec {
   bin: string;
@@ -11,6 +12,7 @@ export interface RunOptions {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   shell?: boolean;
+  stdin?: string;
 }
 
 export interface RunResult {
@@ -52,13 +54,14 @@ export interface HandoffData {
   generatedAt: string;
   repository: string;
   sourceAgent?: string;
-  targetAgent?: string;
   sessionId?: string;
   sessionSummary?: string;
+  compactSummary?: string;
   modifiedFiles: string[];
   gitStatus: string;
   gitDiffStat: string;
   diff?: string;
   repoInstructions: string[];
   locale: Locale;
+  detail: Detail;
 }


### PR DESCRIPTION
## Summary
- Add `--detail summary|standard|full` to `write` and `to`. `summary` invokes the source agent CLI (overridable via `AGENT_HANDOFF_SUMMARIZER_BIN`) to compress the session log so the handoff stays small. (#3)
- Session picker shows a "Latest message" panel for the highlighted session when Tab is pressed; the preview is loaded asynchronously and cached. (#4)
- On macOS, `write` asks whether to copy the generated handoff to `pbcopy` after writing. (#5)
- Drop the `Who is the target agent?` picker from `write` (use `ccrelay to <target>` for the routed case) and keep the TUI uniformly in English.

Closes #3, #4, #5.

## Test plan
- [x] `npm run check` passes (tsc + build + node --check)
- [x] `ccrelay write` interactive flow: locale → source → detail → session picker, then optional pbcopy prompt on macOS
- [x] `summary` detail compresses the session log via the source agent CLI
- [x] Session picker `Tab` toggles the latest-message panel; latest `### User` / `### Assistant` block is shown without trailing template text
- [x] `ccrelay to claude --dry-run` no longer asks for pbcopy

🤖 Generated with [Claude Code](https://claude.com/claude-code)