### PR TITLE
chore: add repository field for npm provenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccrelay",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccrelay",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "bin": {
         "ccrelay": "dist/bin.js"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "0.2.1",
   "description": "Handoff CLI for moving work between coding agents.",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shibukazu/ccrelay.git"
+  },
+  "homepage": "https://github.com/shibukazu/ccrelay#readme",
+  "bugs": {
+    "url": "https://github.com/shibukazu/ccrelay/issues"
+  },
   "bin": {
     "ccrelay": "./dist/bin.js"
   },


### PR DESCRIPTION
## Summary
- Add `repository`, `homepage`, and `bugs` fields to `package.json` so that `npm publish --provenance` can verify the tarball matches the GitHub source recorded in the sigstore provenance bundle.

The previous publish attempts failed with:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/ccrelay
- Error verifying sigstore provenance bundle: Failed to validate repository
  information: package.json: "repository.url" is "", expected to match
  "https://github.com/shibukazu/ccrelay" from provenance
```

## Test plan
- [x] `npm run check` passes
- [ ] Re-run the `release` workflow after merge; npm publish should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)